### PR TITLE
Fixing the drawing of a random amount of cards

### DIFF
--- a/Global.-1.ttslua
+++ b/Global.-1.ttslua
@@ -1318,6 +1318,7 @@ function co()
                 canChallenge = true
                 nextPlayer(1)
               end
+              stacking_Draw = 0
             else
               if challengeButton ~= nil
               then


### PR DESCRIPTION
I fixed the bug mentioned in #1.

The problem was that after a challenging of the "+4" card, the `stacking_Draw` variable didn't get reset.